### PR TITLE
Add more detailed build instructions for Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ git clone git@github.com:msolomon/github-diff-syntax-highlighter.git
 cd github-diff-syntax-highlighter
 # build
 make
-cfx xpi build/firefox/
+cd build
+cfx xpi firefox/
 # install in Firefox
 open -a Firefox github-diff-syntax-highlighter.xpi
 ~~~


### PR DESCRIPTION
I use the Firefox version of this extension. The new installation instructions were vague, so I added information to make it easier for me and others to build next time there is an update.
