### PR TITLE
Note in README that this add-on is now unnecessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Use GitHub's own syntax highlighting for diffs on GitHub
 
 ------------------------
 
+### Note: this extension is now unnecessary
+
+On December 9, 2014, GitHub finally implemented this functionality on the server-side. See GitHub’s announcement [“Syntax Highlighted Diffs”](https://github.com/blog/1932-syntax-highlighted-diffs). Thus, this extension is unnecessary and will be discontinued. Enjoy your diff-reading!
+
+------------------------
+
 GitHub doesn't syntax highlight inside diffs. This extension fixes that.
 
 [Other extensions](https://github.com/danielribeiro/github-diff-highlight-extension) already exist that use a Javascript syntax highlighter to perform a similar task, but this extension instead requests the highligted HTML directly from GitHub and merges it into the page.


### PR DESCRIPTION
This puts a link the README to GitHub’s announcement [“Syntax Highlighted Diffs”](https://github.com/blog/1932-syntax-highlighted-diffs), and says that the extension is discontinued because it is now unnecessary.

Of course, it would be your choice whether to discontinue this extension, but I don’t see what else you would want to do with it now that GitHub has implemented syntax-highlighted diffs itself. I hope you find it a relief that you don’t have to keep up with GitHub’s HTML changes any more.
